### PR TITLE
Allow legacy npm versions to avoid failing dependabot runs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       },
       "engines": {
         "node": "^20.17.0",
-        "npm": "^10.8.2"
+        "npm": ">=9.6.5 <11"
       }
     },
     "node_modules/@apollo/client": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "updates": "npx npm-check-updates  -u"
   },
   "engines": {
-    "npm": "^10.8.2",
+    "npm": ">=9.6.5 <11",
     "node": "^20.17.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "updates": "npx npm-check-updates  -u"
   },
   "engines": {
-    "npm": ">=9.6.5 <11",
-    "node": "^20.17.0"
+    "npm": ">=9.6.5",
+    "node": ">=20.17.0"
   },
   "dependencies": {
     "@apollo/client": "3.11.8",


### PR DESCRIPTION
https://github.com/dependabot/dependabot-core/issues/9277